### PR TITLE
Remove throw() statements in method declarations

### DIFF
--- a/src/libsrc++/cMsg.hxx
+++ b/src/libsrc++/cMsg.hxx
@@ -82,65 +82,65 @@ class cMsgMessage {
   
   
 public:
-  cMsgMessage(void)                   throw(cMsgException);
-  cMsgMessage(const cMsgMessage &m)   throw(cMsgException);
-  cMsgMessage(void *msgPointer) throw(cMsgException);
+  cMsgMessage(void)                  ;
+  cMsgMessage(const cMsgMessage &m)  ;
+  cMsgMessage(void *msgPointer);
   virtual ~cMsgMessage(void);
 
-  virtual string getSubject(void)               const throw(cMsgException);
-  virtual void   setSubject(const string &subject)    throw(cMsgException);
-  virtual string getType(void)                  const throw(cMsgException);
-  virtual void   setType(const string &type)          throw(cMsgException);
-  virtual string getText(void)                  const throw(cMsgException);
-  virtual void   setText(const string &text)          throw(cMsgException);
+  virtual string getSubject(void)               const;
+  virtual void   setSubject(const string &subject)   ;
+  virtual string getType(void)                  const;
+  virtual void   setType(const string &type)         ;
+  virtual string getText(void)                  const;
+  virtual void   setText(const string &text)         ;
   
-  virtual void   setByteArrayLength(int length)       throw(cMsgException);
+  virtual void   setByteArrayLength(int length)      ;
   virtual void   resetByteArrayLength();
   virtual int    getByteArrayLength(void);
   virtual int    getByteArrayLengthFull(void);
-  virtual void   setByteArrayOffset(int offset)       throw(cMsgException);
+  virtual void   setByteArrayOffset(int offset)      ;
   virtual int    getByteArrayOffset(void);  
   virtual int    getByteArrayEndian(void);
-  virtual void   setByteArrayEndian(int endian)       throw(cMsgException);
-  virtual bool   needToSwap(void)               const throw(cMsgException);  
+  virtual void   setByteArrayEndian(int endian)      ;
+  virtual bool   needToSwap(void)               const;  
   virtual char*  getByteArray(void);
-  virtual void   setByteArray(char *array, int length)       throw(cMsgException);
-  virtual void   setByteArrayNoCopy(char* array, int length) throw(cMsgException);
+  virtual void   setByteArray(char *array, int length)      ;
+  virtual void   setByteArrayNoCopy(char* array, int length);
 
-  virtual int    getUserInt(void)               const throw(cMsgException);
-  virtual void   setUserInt(int i)                    throw(cMsgException);
-  virtual struct timespec getUserTime(void)     const throw(cMsgException);
-  virtual void   setUserTime(const struct timespec &userTime) throw(cMsgException);
-  virtual int    getVersion(void)               const throw(cMsgException);
-  virtual string getDomain(void)                const throw(cMsgException);
-  virtual string getReceiver(void)              const throw(cMsgException);
-  virtual string getReceiverHost(void)          const throw(cMsgException);
-  virtual string getSender(void)                const throw(cMsgException);
-  virtual string getSenderHost(void)            const throw(cMsgException);
-  virtual struct timespec getReceiverTime(void) const throw(cMsgException);
-  virtual struct timespec getSenderTime(void)   const throw(cMsgException);
-  virtual bool   isGetRequest(void)             const throw(cMsgException);
-  virtual bool   isGetResponse(void)            const throw(cMsgException);
-  virtual bool   isNullGetResponse(void)        const throw(cMsgException);
+  virtual int    getUserInt(void)               const;
+  virtual void   setUserInt(int i)                   ;
+  virtual struct timespec getUserTime(void)     const;
+  virtual void   setUserTime(const struct timespec &userTime);
+  virtual int    getVersion(void)               const;
+  virtual string getDomain(void)                const;
+  virtual string getReceiver(void)              const;
+  virtual string getReceiverHost(void)          const;
+  virtual string getSender(void)                const;
+  virtual string getSenderHost(void)            const;
+  virtual struct timespec getReceiverTime(void) const;
+  virtual struct timespec getSenderTime(void)   const;
+  virtual bool   isGetRequest(void)             const;
+  virtual bool   isGetResponse(void)            const;
+  virtual bool   isNullGetResponse(void)        const;
 
-  virtual void   makeNullResponse(const cMsgMessage &msg)   throw(cMsgException);
-  virtual void   makeNullResponse(const cMsgMessage *msg)   throw(cMsgException);
-  virtual void   makeResponse(const cMsgMessage &msg)       throw(cMsgException);
-  virtual void   makeResponse(const cMsgMessage *msg)       throw(cMsgException);
+  virtual void   makeNullResponse(const cMsgMessage &msg)  ;
+  virtual void   makeNullResponse(const cMsgMessage *msg)  ;
+  virtual void   makeResponse(const cMsgMessage &msg)      ;
+  virtual void   makeResponse(const cMsgMessage *msg)      ;
 
-  virtual void   setGetResponse(bool b)               throw(cMsgException);
-  virtual void   setNullGetResponse(bool b)           throw(cMsgException);
-  virtual string toString(void)                 const throw(cMsgException);
-  virtual cMsgMessage *copy(void)               const throw(cMsgException);
-  virtual cMsgMessage *nullResponse(void)       const throw(cMsgException);
-  virtual cMsgMessage *response(void)           const throw(cMsgException);
-  virtual string getSubscriptionDomain()        const throw(cMsgException);
-  virtual string getSubscriptionSubject()       const throw(cMsgException);
-  virtual string getSubscriptionType()          const throw(cMsgException);
-  virtual string getSubscriptionUDL()           const throw(cMsgException);
-  virtual int    getSubscriptionCueSize(void)   const throw(cMsgException);
-  virtual bool   getReliableSend(void)          const throw(cMsgException);
-  virtual void   setReliableSend(bool b)              throw(cMsgException);
+  virtual void   setGetResponse(bool b)              ;
+  virtual void   setNullGetResponse(bool b)          ;
+  virtual string toString(void)                 const;
+  virtual cMsgMessage *copy(void)               const;
+  virtual cMsgMessage *nullResponse(void)       const;
+  virtual cMsgMessage *response(void)           const;
+  virtual string getSubscriptionDomain()        const;
+  virtual string getSubscriptionSubject()       const;
+  virtual string getSubscriptionType()          const;
+  virtual string getSubscriptionUDL()           const;
+  virtual int    getSubscriptionCueSize(void)   const;
+  virtual bool   getReliableSend(void)          const;
+  virtual void   setReliableSend(bool b)             ;
   
 
 
@@ -156,76 +156,76 @@ public:
   virtual void   payloadClear(void);
   virtual void   payloadReset(void);
   virtual void   payloadPrint(void) const;
-  virtual void   payloadCopy(const cMsgMessage &msg)            throw(cMsgException);
+  virtual void   payloadCopy(const cMsgMessage &msg)           ;
 
   virtual bool   payloadRemoveField(const string &name);
   virtual string payloadGetText() const;
-  virtual void   payloadSetFromText(const string &txt)          throw(cMsgException);
-  virtual string payloadGetFieldDescription(const string &name) const throw(cMsgException);  
+  virtual void   payloadSetFromText(const string &txt)         ;
+  virtual string payloadGetFieldDescription(const string &name) const;  
   
-  virtual map<string,int> *payloadGet()                         const throw(cMsgException);
+  virtual map<string,int> *payloadGet()                         const;
   virtual int    payloadGetCount()                              const;
   virtual bool   payloadContainsName (const string &name)       const;
-  virtual int    payloadGetType      (const string &name)       const throw(cMsgException);
-  virtual void   setHistoryLengthMax (int len)                  const throw(cMsgException);
+  virtual int    payloadGetType      (const string &name)       const;
+  virtual void   setHistoryLengthMax (int len)                  const;
   
 
   //
   // Methods to get a payload item's value
   //
   virtual void getBinary(const string &name, const char **val, int &len, int &endian)
-               const throw(cMsgException);
+               const;
   virtual void getBinaryArray(const string &name, const char ***vals, int **lens, int **endians, int &count)
-               const throw(cMsgException);
+               const;
 
-  virtual cMsgMessage          *getMessage(const string &name)        const throw(cMsgException);
-  virtual vector<cMsgMessage>  *getMessageVector(const string &name)  const throw(cMsgException);
-  virtual vector<cMsgMessage*> *getMessagePVector(const string &name) const throw(cMsgException);
-  virtual cMsgMessage          *getMessageArray (const string &name)  const throw(cMsgException);
-  virtual cMsgMessage*         *getMessagePArray (const string &name) const throw(cMsgException);
+  virtual cMsgMessage          *getMessage(const string &name)        const;
+  virtual vector<cMsgMessage>  *getMessageVector(const string &name)  const;
+  virtual vector<cMsgMessage*> *getMessagePVector(const string &name) const;
+  virtual cMsgMessage          *getMessageArray (const string &name)  const;
+  virtual cMsgMessage*         *getMessagePArray (const string &name) const;
 
-  virtual string          getString(const string &name)       const throw(cMsgException);
-  virtual vector<string> *getStringVector(const string &name) const throw(cMsgException);
-  virtual string         *getStringArray(const string &name)  const throw(cMsgException);
+  virtual string          getString(const string &name)       const;
+  virtual vector<string> *getStringVector(const string &name) const;
+  virtual string         *getStringArray(const string &name)  const;
   
-  virtual float           getFloat(const string &name)        const throw(cMsgException);
-  virtual vector<float>  *getFloatVector(const string &name)  const throw(cMsgException);
-  virtual float          *getFloatArray(const string &name)   const throw(cMsgException);
+  virtual float           getFloat(const string &name)        const;
+  virtual vector<float>  *getFloatVector(const string &name)  const;
+  virtual float          *getFloatArray(const string &name)   const;
 
-  virtual double          getDouble(const string &name)       const throw(cMsgException);
-  virtual vector<double> *getDoubleVector(const string &name) const throw(cMsgException);
-  virtual double         *getDoubleArray(const string &name)  const throw(cMsgException);
+  virtual double          getDouble(const string &name)       const;
+  virtual vector<double> *getDoubleVector(const string &name) const;
+  virtual double         *getDoubleArray(const string &name)  const;
   
-  virtual int8_t            getInt8  (const string &name)      const throw(cMsgException);
-  virtual int16_t           getInt16 (const string &name)      const throw(cMsgException);
-  virtual int32_t           getInt32 (const string &name)      const throw(cMsgException);
-  virtual int64_t           getInt64 (const string &name)      const throw(cMsgException);
+  virtual int8_t            getInt8  (const string &name)      const;
+  virtual int16_t           getInt16 (const string &name)      const;
+  virtual int32_t           getInt32 (const string &name)      const;
+  virtual int64_t           getInt64 (const string &name)      const;
 
-  virtual vector<int8_t>   *getInt8Vector (const string &name) const throw(cMsgException);
-  virtual vector<int16_t>  *getInt16Vector(const string &name) const throw(cMsgException);
-  virtual vector<int32_t>  *getInt32Vector(const string &name) const throw(cMsgException);
-  virtual vector<int64_t>  *getInt64Vector(const string &name) const throw(cMsgException);
+  virtual vector<int8_t>   *getInt8Vector (const string &name) const;
+  virtual vector<int16_t>  *getInt16Vector(const string &name) const;
+  virtual vector<int32_t>  *getInt32Vector(const string &name) const;
+  virtual vector<int64_t>  *getInt64Vector(const string &name) const;
 
-  virtual int8_t           *getInt8Array  (const string &name) const throw(cMsgException);
-  virtual int16_t          *getInt16Array (const string &name) const throw(cMsgException);
-  virtual int32_t          *getInt32Array (const string &name) const throw(cMsgException);
-  virtual int64_t          *getInt64Array (const string &name) const throw(cMsgException);
+  virtual int8_t           *getInt8Array  (const string &name) const;
+  virtual int16_t          *getInt16Array (const string &name) const;
+  virtual int32_t          *getInt32Array (const string &name) const;
+  virtual int64_t          *getInt64Array (const string &name) const;
 
 
-  virtual uint8_t           getUint8 (const string &name)       const throw(cMsgException);
-  virtual uint16_t          getUint16(const string &name)       const throw(cMsgException);
-  virtual uint32_t          getUint32(const string &name)       const throw(cMsgException);
-  virtual uint64_t          getUint64(const string &name)       const throw(cMsgException);
+  virtual uint8_t           getUint8 (const string &name)       const;
+  virtual uint16_t          getUint16(const string &name)       const;
+  virtual uint32_t          getUint32(const string &name)       const;
+  virtual uint64_t          getUint64(const string &name)       const;
   
-  virtual vector<uint8_t>  *getUint8Vector (const string &name) const throw(cMsgException);
-  virtual vector<uint16_t> *getUint16Vector(const string &name) const throw(cMsgException);
-  virtual vector<uint32_t> *getUint32Vector(const string &name) const throw(cMsgException);
-  virtual vector<uint64_t> *getUint64Vector(const string &name) const throw(cMsgException);
+  virtual vector<uint8_t>  *getUint8Vector (const string &name) const;
+  virtual vector<uint16_t> *getUint16Vector(const string &name) const;
+  virtual vector<uint32_t> *getUint32Vector(const string &name) const;
+  virtual vector<uint64_t> *getUint64Vector(const string &name) const;
 
-  virtual uint8_t          *getUint8Array  (const string &name) const throw(cMsgException);
-  virtual uint16_t         *getUint16Array (const string &name) const throw(cMsgException);
-  virtual uint32_t         *getUint32Array (const string &name) const throw(cMsgException);
-  virtual uint64_t         *getUint64Array (const string &name) const throw(cMsgException);
+  virtual uint8_t          *getUint8Array  (const string &name) const;
+  virtual uint16_t         *getUint16Array (const string &name) const;
+  virtual uint32_t         *getUint32Array (const string &name) const;
+  virtual uint64_t         *getUint64Array (const string &name) const;
   
 
   //
@@ -365,44 +365,44 @@ class cMsg {
 public:
   cMsg(const string &UDL, const string &name, const string &descr);
   virtual ~cMsg(void);
-  virtual void connect()              throw(cMsgException);
-  virtual void disconnect(void)       throw(cMsgException);
-  virtual void send(cMsgMessage &msg) throw(cMsgException);
-  virtual void send(cMsgMessage *msg) throw(cMsgException);
-  virtual int  syncSend(cMsgMessage &msg, const struct timespec *timeout = NULL) throw(cMsgException);
-  virtual int  syncSend(cMsgMessage *msg, const struct timespec *timeout = NULL) throw(cMsgException);
+  virtual void connect()             ;
+  virtual void disconnect(void)      ;
+  virtual void send(cMsgMessage &msg);
+  virtual void send(cMsgMessage *msg);
+  virtual int  syncSend(cMsgMessage &msg, const struct timespec *timeout = NULL);
+  virtual int  syncSend(cMsgMessage *msg, const struct timespec *timeout = NULL);
   virtual void *subscribe(const string &subject, const string &type, cMsgCallback *cb, void *userArg, 
-                          const cMsgSubscriptionConfig *cfg = NULL) throw(cMsgException);
+                          const cMsgSubscriptionConfig *cfg = NULL);
   virtual void *subscribe(const string &subject, const string &type, cMsgCallback &cb, void *userArg,
-                          const cMsgSubscriptionConfig *cfg = NULL) throw(cMsgException);
-  virtual void unsubscribe(void *handle) throw(cMsgException);
-  virtual void subscriptionPause(void *handle)         throw(cMsgException);
-  virtual void subscriptionResume(void *handle)        throw(cMsgException);
-  virtual void subscriptionQueueClear(void *handle)    throw(cMsgException);
-  virtual int  subscriptionQueueCount(void *handle)    throw(cMsgException);
-  virtual bool subscriptionQueueIsFull(void *handle)   throw(cMsgException);
-  virtual int  subscriptionMessagesTotal(void *handle) throw(cMsgException);
+                          const cMsgSubscriptionConfig *cfg = NULL);
+  virtual void unsubscribe(void *handle);
+  virtual void subscriptionPause(void *handle)        ;
+  virtual void subscriptionResume(void *handle)       ;
+  virtual void subscriptionQueueClear(void *handle)   ;
+  virtual int  subscriptionQueueCount(void *handle)   ;
+  virtual bool subscriptionQueueIsFull(void *handle)  ;
+  virtual int  subscriptionMessagesTotal(void *handle);
   virtual cMsgMessage *sendAndGet(cMsgMessage &sendMsg, const struct timespec *timeout = NULL)
-    throw(cMsgException);
+   ;
   virtual cMsgMessage *sendAndGet(cMsgMessage *sendMsg, const struct timespec *timeout = NULL)
-    throw(cMsgException);
+   ;
   virtual cMsgMessage *subscribeAndGet(const string &subject, const string &type, const struct timespec *timeout = NULL)
-    throw(cMsgException);
-  virtual void   flush(const struct timespec *timeout = NULL) throw(cMsgException);
-  virtual void   start(void) throw(cMsgException);
-  virtual void   stop(void)  throw(cMsgException);
-  virtual void   setUDL(const string &udl) throw(cMsgException);
+   ;
+  virtual void   flush(const struct timespec *timeout = NULL);
+  virtual void   start(void);
+  virtual void   stop(void) ;
+  virtual void   setUDL(const string &udl);
   virtual string getUDL(void)         const;
-  virtual string getCurrentUDL(void)  const throw(cMsgException);
+  virtual string getCurrentUDL(void)  const;
   virtual string getName(void)        const;
   virtual string getDescription(void) const;
-  virtual bool   isConnected(void)    const throw(cMsgException);
-  virtual bool   isReceiving(void)    const throw(cMsgException);
-  virtual void   setShutdownHandler(cMsgShutdownHandler *handler, void* userArg) throw(cMsgException);
-  virtual void   shutdownClients(const string &client, int flag) throw(cMsgException);
-  virtual void   shutdownServers(const string &server, int flag) throw(cMsgException);
-  virtual cMsgMessage *monitor(const string &monString)          throw(cMsgException);
-  virtual void setMonitoringString(const string &monString)      throw(cMsgException);
+  virtual bool   isConnected(void)    const;
+  virtual bool   isReceiving(void)    const;
+  virtual void   setShutdownHandler(cMsgShutdownHandler *handler, void* userArg);
+  virtual void   shutdownClients(const string &client, int flag);
+  virtual void   shutdownServers(const string &server, int flag);
+  virtual cMsgMessage *monitor(const string &monString)         ;
+  virtual void setMonitoringString(const string &monString)     ;
 
 
 private:

--- a/src/libsrc++/cMsgPayload.cc
+++ b/src/libsrc++/cMsgPayload.cc
@@ -146,7 +146,7 @@ namespace cmsg {
      * @throws cMsgException if no payload/field exists, or if name is NULL
      */
     int cMsgMessage::payloadGetType(const string &name) const
-            throw(cMsgException) {
+            {
         int err, type;
         err = cMsgPayloadGetType(myMsgPointer, name.c_str(), &type);
         if (err != CMSG_OK) {
@@ -167,7 +167,7 @@ namespace cmsg {
      * @param msg reference to message to copy payload from
      * @throws cMsgException if no memory
      */
-    void cMsgMessage::payloadCopy(const cMsgMessage &msg) throw(cMsgException) {
+    void cMsgMessage::payloadCopy(const cMsgMessage &msg) {
         int err = cMsgPayloadCopy(msg.myMsgPointer, myMsgPointer);
         if (err!= CMSG_OK) {
             throw(cMsgException(cMsgPerror(err),err));
@@ -199,7 +199,7 @@ namespace cmsg {
      * @param txt string representing payload
      */
     void cMsgMessage::payloadSetFromText(const string &txt)
-          throw(cMsgException) {
+          {
         int err = cMsgPayloadSetAllFieldsFromText(myMsgPointer, txt.c_str());
         if (err != CMSG_OK) {
             throw(cMsgException(cMsgPerror(err),err));
@@ -216,7 +216,7 @@ namespace cmsg {
      * @throws cMsgException if no such field in the payload
      */
     string cMsgMessage::payloadGetFieldDescription(const string &name) const
-            throw(cMsgException) {
+            {
         const char *field = cMsgPayloadFieldDescription(myMsgPointer, name.c_str());
         if (field == NULL) {
             string err("No such field as ");
@@ -237,7 +237,7 @@ namespace cmsg {
      * @return a pointer to a map containing all name/type pairs of the payload
      * @throws cMsgException if no payload exists, or if name is NULL
      */
-    map<string,int> *cMsgMessage::payloadGet() const throw(cMsgException) {
+    map<string,int> *cMsgMessage::payloadGet() const {
         char **names;
         int *types, len;
 
@@ -284,7 +284,7 @@ namespace cmsg {
      *
      * @throws cMsgException if len < 0 or > CMSG_HISTORY_LENGTH_ABS_MAX
      */
-    void cMsgMessage::setHistoryLengthMax(int len) const throw(cMsgException) {
+    void cMsgMessage::setHistoryLengthMax(int len) const {
         int err = cMsgSetHistoryLengthMax(myMsgPointer, len);
         if (err != CMSG_OK) throw (cMsgException("len must be >= 0 and < CMSG_HISTORY_LENGTH_ABS_MAX"));
     }
@@ -310,7 +310,7 @@ namespace cmsg {
  *                        or if any arg is NULL
  */
 void cMsgMessage::getBinary(const string &name, const char **val, int &len, int &endian)
-        const throw(cMsgException) {
+        const {
     int err = cMsgGetBinary(myMsgPointer, name.c_str(), val, &len, &endian);
     if (err != CMSG_OK) {
         if (err == CMSG_BAD_FORMAT) throw(cMsgException("Wrong field type"));
@@ -334,7 +334,7 @@ void cMsgMessage::getBinary(const string &name, const char **val, int &len, int 
  */
 void cMsgMessage::getBinaryArray(const string &name, const char ***vals,
                                  int **lens, int **endians, int &count)
-        const throw(cMsgException) {
+        const {
     int err = cMsgGetBinaryArray(myMsgPointer, name.c_str(), vals, lens, endians, &count);
     if (err != CMSG_OK) {
         if (err == CMSG_BAD_FORMAT) throw(cMsgException("Wrong field type"));
@@ -356,7 +356,7 @@ void cMsgMessage::getBinaryArray(const string &name, const char ***vals,
  * @return field's value as cMsg message
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-cMsgMessage *cMsgMessage::getMessage(const string &name) const throw(cMsgException) {
+cMsgMessage *cMsgMessage::getMessage(const string &name) const {
   const void *val;
   int err = cMsgGetMessage(myMsgPointer, name.c_str(), &val);
   if (err != CMSG_OK) {
@@ -386,7 +386,7 @@ cMsgMessage *cMsgMessage::getMessage(const string &name) const throw(cMsgExcepti
  * @return field's value as vector of pointers to cMsgMessage objects
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-vector<cMsgMessage*> *cMsgMessage::getMessagePVector(const string &name) const throw(cMsgException) {
+vector<cMsgMessage*> *cMsgMessage::getMessagePVector(const string &name) const {
   int len;
   const void **vals;
   int err = cMsgGetMessageArray(myMsgPointer, name.c_str(), &vals, &len);
@@ -417,7 +417,7 @@ vector<cMsgMessage*> *cMsgMessage::getMessagePVector(const string &name) const t
  * @return field's value as vector of cMsgMessage objects
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-vector<cMsgMessage> *cMsgMessage::getMessageVector(const string &name) const throw(cMsgException) {
+vector<cMsgMessage> *cMsgMessage::getMessageVector(const string &name) const {
   int len;
   const void **vals;
   int err = cMsgGetMessageArray(myMsgPointer, name.c_str(), &vals, &len);
@@ -448,7 +448,7 @@ vector<cMsgMessage> *cMsgMessage::getMessageVector(const string &name) const thr
  * @return field's value as array of pointers to cMsgMessage objects
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-cMsgMessage* *cMsgMessage::getMessagePArray(const string &name) const throw(cMsgException) {
+cMsgMessage* *cMsgMessage::getMessagePArray(const string &name) const {
   int len;
   const void **vals;
   int err = cMsgGetMessageArray(myMsgPointer, name.c_str(), &vals, &len);
@@ -478,7 +478,7 @@ cMsgMessage* *cMsgMessage::getMessagePArray(const string &name) const throw(cMsg
  * @return field's value as array of cMsgMessage objects
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-cMsgMessage *cMsgMessage::getMessageArray(const string &name) const throw(cMsgException) {
+cMsgMessage *cMsgMessage::getMessageArray(const string &name) const {
   int len;
   const void **vals;
   int err = cMsgGetMessageArray(myMsgPointer, name.c_str(), &vals, &len);
@@ -506,7 +506,7 @@ cMsgMessage *cMsgMessage::getMessageArray(const string &name) const throw(cMsgEx
  * @return field's value as string
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-string cMsgMessage::getString(const string &name) const throw(cMsgException) {
+string cMsgMessage::getString(const string &name) const {
   const char *val;
   int err = cMsgGetString(myMsgPointer, name.c_str(), &val);
   if (err != CMSG_OK) {
@@ -530,7 +530,7 @@ string cMsgMessage::getString(const string &name) const throw(cMsgException) {
  * @return field's value as vector of strings
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-vector<string> *cMsgMessage::getStringVector(const string &name) const throw(cMsgException) {
+vector<string> *cMsgMessage::getStringVector(const string &name) const {
   int len;
   const char **vals;
   int err = cMsgGetStringArray(myMsgPointer, name.c_str(), &vals, &len);
@@ -558,7 +558,7 @@ vector<string> *cMsgMessage::getStringVector(const string &name) const throw(cMs
  * @return field's value as vector of strings
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-string *cMsgMessage::getStringArray(const string &name) const throw(cMsgException) {
+string *cMsgMessage::getStringArray(const string &name) const {
   int len;
   const char **vals;
   int err = cMsgGetStringArray(myMsgPointer, name.c_str(), &vals, &len);
@@ -585,7 +585,7 @@ string *cMsgMessage::getStringArray(const string &name) const throw(cMsgExceptio
  * @return field's value as a float
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-float cMsgMessage::getFloat(const string &name) const throw(cMsgException) {
+float cMsgMessage::getFloat(const string &name) const {
   float val;
   int err = cMsgGetFloat(myMsgPointer, name.c_str(), &val);
   if (err != CMSG_OK) {
@@ -604,7 +604,7 @@ float cMsgMessage::getFloat(const string &name) const throw(cMsgException) {
  * @return field's value as a double
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-double cMsgMessage::getDouble(const string &name) const throw(cMsgException) {
+double cMsgMessage::getDouble(const string &name) const {
   double val;
   int err = cMsgGetDouble(myMsgPointer, name.c_str(), &val);
   if (err != CMSG_OK) {
@@ -628,7 +628,7 @@ double cMsgMessage::getDouble(const string &name) const throw(cMsgException) {
  * @return field's value as vector of floats
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-vector<float> *cMsgMessage::getFloatVector(const string &name) const throw(cMsgException) {
+vector<float> *cMsgMessage::getFloatVector(const string &name) const {
   int len;
   const float *vals;
   int err = cMsgGetFloatArray(myMsgPointer, name.c_str(), &vals, &len);
@@ -655,7 +655,7 @@ vector<float> *cMsgMessage::getFloatVector(const string &name) const throw(cMsgE
  * @return field's value as array of floats
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-float *cMsgMessage::getFloatArray(const string &name) const throw(cMsgException) {
+float *cMsgMessage::getFloatArray(const string &name) const {
   int len;
   const float *vals;
   int err = cMsgGetFloatArray(myMsgPointer, name.c_str(), &vals, &len);
@@ -683,7 +683,7 @@ float *cMsgMessage::getFloatArray(const string &name) const throw(cMsgException)
  * @return field's value as vector of doubles
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-vector<double> *cMsgMessage::getDoubleVector(const string &name) const throw(cMsgException) {
+vector<double> *cMsgMessage::getDoubleVector(const string &name) const {
   int len;
   const double *vals;
   int err = cMsgGetDoubleArray(myMsgPointer, name.c_str(), &vals, &len);
@@ -711,7 +711,7 @@ vector<double> *cMsgMessage::getDoubleVector(const string &name) const throw(cMs
  * @return field's value as array of doubles
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-double *cMsgMessage::getDoubleArray(const string &name) const throw(cMsgException) {
+double *cMsgMessage::getDoubleArray(const string &name) const {
   int len;
   const double *vals;
   int err = cMsgGetDoubleArray(myMsgPointer, name.c_str(), &vals, &len);
@@ -738,7 +738,7 @@ double *cMsgMessage::getDoubleArray(const string &name) const throw(cMsgExceptio
  * @return field's value as an 8-bit, signed integer
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-int8_t cMsgMessage::getInt8(const string &name) const throw(cMsgException) {
+int8_t cMsgMessage::getInt8(const string &name) const {
   int8_t val;
   int err = cMsgGetInt8(myMsgPointer, name.c_str(), &val);
   if (err != CMSG_OK) {
@@ -757,7 +757,7 @@ int8_t cMsgMessage::getInt8(const string &name) const throw(cMsgException) {
  * @return field's value as an 16-bit, signed integer
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-int16_t cMsgMessage::getInt16(const string &name) const throw(cMsgException) {
+int16_t cMsgMessage::getInt16(const string &name) const {
   int16_t val;
   int err = cMsgGetInt16(myMsgPointer, name.c_str(), &val);
   if (err != CMSG_OK) {
@@ -776,7 +776,7 @@ int16_t cMsgMessage::getInt16(const string &name) const throw(cMsgException) {
  * @return field's value as an 32-bit, signed integer
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-int32_t cMsgMessage::getInt32(const string &name) const throw(cMsgException) {
+int32_t cMsgMessage::getInt32(const string &name) const {
   int32_t val;
   int err = cMsgGetInt32(myMsgPointer, name.c_str(), &val);
   if (err != CMSG_OK) {
@@ -795,7 +795,7 @@ int32_t cMsgMessage::getInt32(const string &name) const throw(cMsgException) {
  * @return field's value as an 64-bit, signed integer
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-int64_t cMsgMessage::getInt64(const string &name) const throw(cMsgException) {
+int64_t cMsgMessage::getInt64(const string &name) const {
   int64_t val;
   int err = cMsgGetInt64(myMsgPointer, name.c_str(), &val);
   if (err != CMSG_OK) {
@@ -814,7 +814,7 @@ int64_t cMsgMessage::getInt64(const string &name) const throw(cMsgException) {
  * @return field's value as an 8-bit, unsigned integer
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-uint8_t cMsgMessage::getUint8(const string &name) const throw(cMsgException) {
+uint8_t cMsgMessage::getUint8(const string &name) const {
   uint8_t val;
   int err = cMsgGetUint8(myMsgPointer, name.c_str(), &val);
   if (err != CMSG_OK) {
@@ -833,7 +833,7 @@ uint8_t cMsgMessage::getUint8(const string &name) const throw(cMsgException) {
  * @return field's value as an 16-bit, unsigned integer
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-uint16_t cMsgMessage::getUint16(const string &name) const throw(cMsgException) {
+uint16_t cMsgMessage::getUint16(const string &name) const {
   uint16_t val;
   int err = cMsgGetUint16(myMsgPointer, name.c_str(), &val);
   if (err != CMSG_OK) {
@@ -852,7 +852,7 @@ uint16_t cMsgMessage::getUint16(const string &name) const throw(cMsgException) {
  * @return field's value as an 32-bit, unsigned integer
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-uint32_t cMsgMessage::getUint32(const string &name) const throw(cMsgException) {
+uint32_t cMsgMessage::getUint32(const string &name) const {
   uint32_t val;
   int err = cMsgGetUint32(myMsgPointer, name.c_str(), &val);
   if (err != CMSG_OK) {
@@ -871,7 +871,7 @@ uint32_t cMsgMessage::getUint32(const string &name) const throw(cMsgException) {
  * @return field's value as an 64-bit, unsigned integer
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-uint64_t cMsgMessage::getUint64(const string &name) const throw(cMsgException) {
+uint64_t cMsgMessage::getUint64(const string &name) const {
   uint64_t val;
   int err = cMsgGetUint64(myMsgPointer, name.c_str(), &val);
   if (err != CMSG_OK) {
@@ -894,7 +894,7 @@ uint64_t cMsgMessage::getUint64(const string &name) const throw(cMsgException) {
  * @return field's value as vector of 8 bit, signed ints
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-vector<int8_t> *cMsgMessage::getInt8Vector(const string &name) const throw(cMsgException) {
+vector<int8_t> *cMsgMessage::getInt8Vector(const string &name) const {
   int len;
   const int8_t *vals;
   int err = cMsgGetInt8Array(myMsgPointer, name.c_str(), &vals, &len);
@@ -921,7 +921,7 @@ vector<int8_t> *cMsgMessage::getInt8Vector(const string &name) const throw(cMsgE
  * @return field's value as vector of 8 bit, signed ints
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-int8_t *cMsgMessage::getInt8Array(const string &name) const throw(cMsgException) {
+int8_t *cMsgMessage::getInt8Array(const string &name) const {
   int len;
   const int8_t *vals;
   int err = cMsgGetInt8Array(myMsgPointer, name.c_str(), &vals, &len);
@@ -948,7 +948,7 @@ int8_t *cMsgMessage::getInt8Array(const string &name) const throw(cMsgException)
  * @return field's value as vector of 16 bit, signed ints
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-vector<int16_t> *cMsgMessage::getInt16Vector(const string &name) const throw(cMsgException) {
+vector<int16_t> *cMsgMessage::getInt16Vector(const string &name) const {
   int len;
   const int16_t *vals;
   int err = cMsgGetInt16Array(myMsgPointer, name.c_str(), &vals, &len);
@@ -975,7 +975,7 @@ vector<int16_t> *cMsgMessage::getInt16Vector(const string &name) const throw(cMs
  * @return field's value as array of 16 bit, signed ints
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-int16_t *cMsgMessage::getInt16Array(const string &name) const throw(cMsgException) {
+int16_t *cMsgMessage::getInt16Array(const string &name) const {
   int len;
   const int16_t *vals;
   int err = cMsgGetInt16Array(myMsgPointer, name.c_str(), &vals, &len);
@@ -1002,7 +1002,7 @@ int16_t *cMsgMessage::getInt16Array(const string &name) const throw(cMsgExceptio
  * @return field's value as vector of 32 bit, signed ints
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-vector<int32_t> *cMsgMessage::getInt32Vector(const string &name) const throw(cMsgException) {
+vector<int32_t> *cMsgMessage::getInt32Vector(const string &name) const {
   int len;
   const int32_t *vals;
   int err = cMsgGetInt32Array(myMsgPointer, name.c_str(), &vals, &len);
@@ -1029,7 +1029,7 @@ vector<int32_t> *cMsgMessage::getInt32Vector(const string &name) const throw(cMs
  * @return field's value as array of 32 bit, signed ints
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-int32_t *cMsgMessage::getInt32Array(const string &name) const throw(cMsgException) {
+int32_t *cMsgMessage::getInt32Array(const string &name) const {
   int len;
   const int32_t *vals;
   int err = cMsgGetInt32Array(myMsgPointer, name.c_str(), &vals, &len);
@@ -1056,7 +1056,7 @@ int32_t *cMsgMessage::getInt32Array(const string &name) const throw(cMsgExceptio
  * @return field's value as vector of 64 bit, signed ints
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-vector<int64_t> *cMsgMessage::getInt64Vector(const string &name) const throw(cMsgException) {
+vector<int64_t> *cMsgMessage::getInt64Vector(const string &name) const {
   int len;
   const int64_t *vals;
   int err = cMsgGetInt64Array(myMsgPointer, name.c_str(), &vals, &len);
@@ -1083,7 +1083,7 @@ vector<int64_t> *cMsgMessage::getInt64Vector(const string &name) const throw(cMs
  * @return field's value as array of 64 bit, signed ints
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-int64_t *cMsgMessage::getInt64Array(const string &name) const throw(cMsgException) {
+int64_t *cMsgMessage::getInt64Array(const string &name) const {
   int len;
   const int64_t *vals;
   int err = cMsgGetInt64Array(myMsgPointer, name.c_str(), &vals, &len);
@@ -1111,7 +1111,7 @@ int64_t *cMsgMessage::getInt64Array(const string &name) const throw(cMsgExceptio
  * @return field's value as vector of 8 bit, unsigned ints
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-vector<uint8_t> *cMsgMessage::getUint8Vector(const string &name) const throw(cMsgException) {
+vector<uint8_t> *cMsgMessage::getUint8Vector(const string &name) const {
   int len;
   const uint8_t *vals;
   int err = cMsgGetUint8Array(myMsgPointer, name.c_str(), &vals, &len);
@@ -1139,7 +1139,7 @@ vector<uint8_t> *cMsgMessage::getUint8Vector(const string &name) const throw(cMs
  * @return field's value as array of 8 bit, unsigned ints
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-uint8_t *cMsgMessage::getUint8Array(const string &name) const throw(cMsgException) {
+uint8_t *cMsgMessage::getUint8Array(const string &name) const {
   int len;
   const uint8_t *vals;
   int err = cMsgGetUint8Array(myMsgPointer, name.c_str(), &vals, &len);
@@ -1167,7 +1167,7 @@ uint8_t *cMsgMessage::getUint8Array(const string &name) const throw(cMsgExceptio
  * @return field's value as vector of 16 bit, unsigned ints
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-vector<uint16_t> *cMsgMessage::getUint16Vector(const string &name) const throw(cMsgException) {
+vector<uint16_t> *cMsgMessage::getUint16Vector(const string &name) const {
   int len;
   const uint16_t *vals;
   int err = cMsgGetUint16Array(myMsgPointer, name.c_str(), &vals, &len);
@@ -1195,7 +1195,7 @@ vector<uint16_t> *cMsgMessage::getUint16Vector(const string &name) const throw(c
  * @return field's value as array of 16 bit, unsigned ints
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-uint16_t *cMsgMessage::getUint16Array(const string &name) const throw(cMsgException) {
+uint16_t *cMsgMessage::getUint16Array(const string &name) const {
   int len;
   const uint16_t *vals;
   int err = cMsgGetUint16Array(myMsgPointer, name.c_str(), &vals, &len);
@@ -1222,7 +1222,7 @@ uint16_t *cMsgMessage::getUint16Array(const string &name) const throw(cMsgExcept
  * @return field's value as vector of 32 bit, unsigned ints
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-vector<uint32_t> *cMsgMessage::getUint32Vector(const string &name) const throw(cMsgException) {
+vector<uint32_t> *cMsgMessage::getUint32Vector(const string &name) const {
   int len;
   const uint32_t *vals;
   int err = cMsgGetUint32Array(myMsgPointer, name.c_str(), &vals, &len);
@@ -1249,7 +1249,7 @@ vector<uint32_t> *cMsgMessage::getUint32Vector(const string &name) const throw(c
  * @return field's value as array of 32 bit, unsigned ints
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-uint32_t *cMsgMessage::getUint32Array(const string &name) const throw(cMsgException) {
+uint32_t *cMsgMessage::getUint32Array(const string &name) const {
   int len;
   const uint32_t *vals;
   int err = cMsgGetUint32Array(myMsgPointer, name.c_str(), &vals, &len);
@@ -1276,7 +1276,7 @@ uint32_t *cMsgMessage::getUint32Array(const string &name) const throw(cMsgExcept
  * @return field's value as vector of 64 bit, unsigned ints
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-vector<uint64_t> *cMsgMessage::getUint64Vector(const string &name) const throw(cMsgException) {
+vector<uint64_t> *cMsgMessage::getUint64Vector(const string &name) const {
   int len;
   const uint64_t *vals;
   int err = cMsgGetUint64Array(myMsgPointer, name.c_str(), &vals, &len);
@@ -1304,7 +1304,7 @@ vector<uint64_t> *cMsgMessage::getUint64Vector(const string &name) const throw(c
  * @return field's value as array of 64 bit, unsigned ints
  * @throws cMsgException if no payload/field exists or field is not right type
  */   
-uint64_t *cMsgMessage::getUint64Array(const string &name) const throw(cMsgException) {
+uint64_t *cMsgMessage::getUint64Array(const string &name) const {
   int len;
   const uint64_t *vals;
   int err = cMsgGetUint64Array(myMsgPointer, name.c_str(), &vals, &len);

--- a/src/libsrc++/cMsgPrivate.hxx
+++ b/src/libsrc++/cMsgPrivate.hxx
@@ -42,7 +42,7 @@ public:
    * @param t Object pointer
    * @param mfp Member function pointer
    */
-  cMsgDispatcher(T *t, void (T::*mfp)(cMsgMessage *msg, void* userArg)) throw(cMsgException*) : t(t), mfp(mfp) {}
+  cMsgDispatcher(T *t, void (T::*mfp)(cMsgMessage *msg, void* userArg)): t(t), mfp(mfp) {}
 
 
   /** Callback method dispatches to member function. 
@@ -50,7 +50,7 @@ public:
    * @param msg Message. 
    * @param userArg User arg.
    */
-  void callback(cMsgMessage *msg, void* userArg) throw(cMsgException) {
+  void callback(cMsgMessage *msg, void* userArg) {
     (t->*mfp)(msg,userArg);
   }
 

--- a/src/libsrc++/cMsgWrapper.cc
+++ b/src/libsrc++/cMsgWrapper.cc
@@ -306,7 +306,7 @@ const char *cMsgException::what(void) const throw() {
  * Default constructor creates message.
  * @throws cMsgException
  */
-cMsgMessage::cMsgMessage(void) throw(cMsgException) {
+cMsgMessage::cMsgMessage(void) {
     
   myMsgPointer=cMsgCreateMessage();
   if(myMsgPointer==NULL) {
@@ -324,7 +324,7 @@ cMsgMessage::cMsgMessage(void) throw(cMsgException) {
  * @param msg The other message
  * @throws cMsgException
  */
-cMsgMessage::cMsgMessage(const cMsgMessage &msg) throw(cMsgException) {
+cMsgMessage::cMsgMessage(const cMsgMessage &msg) {
 
   myMsgPointer=cMsgCopyMessage(msg.myMsgPointer);
   if(myMsgPointer==NULL) {
@@ -342,7 +342,7 @@ cMsgMessage::cMsgMessage(const cMsgMessage &msg) throw(cMsgException) {
  * @param msgPointer  C pointer to message
  * @throws cMsgException
  */
-cMsgMessage::cMsgMessage(void *msgPointer) throw(cMsgException) {
+cMsgMessage::cMsgMessage(void *msgPointer) {
 
   myMsgPointer=msgPointer;
   if(myMsgPointer==NULL) {
@@ -371,7 +371,7 @@ cMsgMessage::~cMsgMessage(void) {
  * @return Message subject
  * @throws cMsgException
  */
-string cMsgMessage::getSubject(void) const throw(cMsgException) {
+string cMsgMessage::getSubject(void) const {
 
   const char *s;
 
@@ -397,7 +397,7 @@ string cMsgMessage::getSubject(void) const throw(cMsgException) {
  * @param subject Message subject
  * @throws cMsgException
  */
-void cMsgMessage::setSubject(const string &subject) throw(cMsgException) {
+void cMsgMessage::setSubject(const string &subject) {
 
   int stat;
   if((stat=cMsgSetSubject(myMsgPointer,subject.c_str()))!=CMSG_OK) {
@@ -415,7 +415,7 @@ void cMsgMessage::setSubject(const string &subject) throw(cMsgException) {
  * @return Message type
  * @throws cMsgException
  */
-string cMsgMessage::getType(void) const throw(cMsgException) {
+string cMsgMessage::getType(void) const {
 
   const char *s;
 
@@ -441,7 +441,7 @@ string cMsgMessage::getType(void) const throw(cMsgException) {
  * @param type Message type
  * @throws cMsgException
  */
-void cMsgMessage::setType(const string &type) throw(cMsgException) {
+void cMsgMessage::setType(const string &type) {
 
   int stat;
   if((stat=cMsgSetType(myMsgPointer,type.c_str()))!=CMSG_OK) {
@@ -459,7 +459,7 @@ void cMsgMessage::setType(const string &type) throw(cMsgException) {
  * @return Message text
  * @throws cMsgException
  */
-string cMsgMessage::getText(void) const throw(cMsgException) {
+string cMsgMessage::getText(void) const {
 
   const char *s;
 
@@ -485,7 +485,7 @@ string cMsgMessage::getText(void) const throw(cMsgException) {
  * @param text Message text
  * @throws cMsgException
  */
-void cMsgMessage::setText(const string &text) throw(cMsgException) {
+void cMsgMessage::setText(const string &text) {
 
   int stat;
   if((stat=cMsgSetText(myMsgPointer,text.c_str()))!=CMSG_OK) {
@@ -503,7 +503,7 @@ void cMsgMessage::setText(const string &text) throw(cMsgException) {
  * @param length Array length in bytes
  * @throws cMsgException
  */
-void cMsgMessage::setByteArrayLength(int length) throw(cMsgException) {
+void cMsgMessage::setByteArrayLength(int length) {
 
   int stat;
   if((stat=cMsgSetByteArrayLength(myMsgPointer,length)!=CMSG_OK)) {
@@ -564,7 +564,7 @@ int cMsgMessage::getByteArrayLengthFull(void) {
  * @param offset Offset in byte array
  * @throws cMsgException
  */
-void cMsgMessage::setByteArrayOffset(int offset) throw(cMsgException) {
+void cMsgMessage::setByteArrayOffset(int offset) {
 
   int stat;
   if((stat=cMsgSetByteArrayOffset(myMsgPointer,offset)!=CMSG_OK)) {
@@ -599,7 +599,7 @@ int cMsgMessage::getByteArrayOffset(void) {
  * @param length Length of byte array in bytes
  * @throws cMsgException
  */
-void cMsgMessage::setByteArray(char *array, int length) throw(cMsgException) {
+void cMsgMessage::setByteArray(char *array, int length) {
 
   int stat;
   if((stat=cMsgSetByteArray(myMsgPointer,array, length)!=CMSG_OK)) {
@@ -618,7 +618,7 @@ void cMsgMessage::setByteArray(char *array, int length) throw(cMsgException) {
  * @param length Length of byte array in bytes
  * @throws cMsgException
  */
-void cMsgMessage::setByteArrayNoCopy(char* array, int length) throw(cMsgException) {
+void cMsgMessage::setByteArrayNoCopy(char* array, int length) {
 
   int stat;
   if((stat=cMsgSetByteArrayNoCopy(myMsgPointer,array,length)!=CMSG_OK)) {
@@ -681,7 +681,7 @@ int cMsgMessage::getByteArrayEndian(void) {
  * @param endian Endian-ness value
  * @throws cMsgException
  */
-void cMsgMessage::setByteArrayEndian(int endian) throw(cMsgException) {
+void cMsgMessage::setByteArrayEndian(int endian) {
   int stat;
 
   if((stat=cMsgSetByteArrayEndian(myMsgPointer,endian))!=CMSG_OK) {
@@ -701,7 +701,7 @@ void cMsgMessage::setByteArrayEndian(int endian) throw(cMsgException) {
  * @return True if must swap
  * @throws cMsgException
  */
-bool cMsgMessage::needToSwap(void) const throw(cMsgException) {
+bool cMsgMessage::needToSwap(void) const {
 
   int flag,stat;
 
@@ -722,7 +722,7 @@ bool cMsgMessage::needToSwap(void) const throw(cMsgException) {
  * @return User int
  * @throws cMsgException
  */
-int cMsgMessage::getUserInt(void) const throw(cMsgException) {
+int cMsgMessage::getUserInt(void) const {
 
   int i;
 
@@ -743,7 +743,7 @@ int cMsgMessage::getUserInt(void) const throw(cMsgException) {
  * @param i User int
  * @throws cMsgException
  */
-void cMsgMessage::setUserInt(int i) throw(cMsgException) {
+void cMsgMessage::setUserInt(int i) {
 
   int stat;
   if((stat=cMsgSetUserInt(myMsgPointer,i))!=CMSG_OK) {
@@ -761,7 +761,7 @@ void cMsgMessage::setUserInt(int i) throw(cMsgException) {
  * @return Timespec holding user time
  * @throws cMsgException
  */
-struct timespec cMsgMessage::getUserTime(void) const throw(cMsgException) {
+struct timespec cMsgMessage::getUserTime(void) const {
 
   struct timespec t;
 
@@ -781,7 +781,7 @@ struct timespec cMsgMessage::getUserTime(void) const throw(cMsgException) {
  *
  * @param userTime Timespec holding user time
  */
-void cMsgMessage::setUserTime(const struct timespec &userTime) throw(cMsgException) {
+void cMsgMessage::setUserTime(const struct timespec &userTime) {
 
   int stat;
   if((stat=cMsgSetUserTime(myMsgPointer, &userTime))!=CMSG_OK) {
@@ -798,7 +798,7 @@ void cMsgMessage::setUserTime(const struct timespec &userTime) throw(cMsgExcepti
  *
  * @return Version
  */
-int cMsgMessage::getVersion(void) const throw(cMsgException) {
+int cMsgMessage::getVersion(void) const {
 
   int version;
 
@@ -818,7 +818,7 @@ int cMsgMessage::getVersion(void) const throw(cMsgException) {
  *
  * @return Copy of message
  */
-cMsgMessage *cMsgMessage::copy(void) const throw(cMsgException) {
+cMsgMessage *cMsgMessage::copy(void) const {
 
   void *newPointer = cMsgCopyMessage(myMsgPointer);
   return(new cMsgMessage(newPointer));
@@ -834,7 +834,7 @@ cMsgMessage *cMsgMessage::copy(void) const throw(cMsgException) {
  * @return Domain
  * @throws cMsgException
  */
-string cMsgMessage::getDomain(void) const throw(cMsgException) {
+string cMsgMessage::getDomain(void) const {
 
   const char *s;
 
@@ -860,7 +860,7 @@ string cMsgMessage::getDomain(void) const throw(cMsgException) {
  * @return Receiver
  * @throws cMsgException
  */
-string cMsgMessage::getReceiver(void) const throw(cMsgException) {
+string cMsgMessage::getReceiver(void) const {
 
   const char *s;
 
@@ -886,7 +886,7 @@ string cMsgMessage::getReceiver(void) const throw(cMsgException) {
  * @return Receiver host
  * @throws cMsgException
  */
-string cMsgMessage::getReceiverHost(void) const throw(cMsgException) {
+string cMsgMessage::getReceiverHost(void) const {
 
   const char *s;
 
@@ -912,7 +912,7 @@ string cMsgMessage::getReceiverHost(void) const throw(cMsgException) {
  * @return Sender
  * @throws cMsgException
  */
-string cMsgMessage::getSender(void) const throw(cMsgException) {
+string cMsgMessage::getSender(void) const {
 
   const char *s;
 
@@ -938,7 +938,7 @@ string cMsgMessage::getSender(void) const throw(cMsgException) {
  * @return Sender host
  * @throws cMsgException
  */
-string cMsgMessage::getSenderHost(void) const throw(cMsgException) {
+string cMsgMessage::getSenderHost(void) const {
 
   const char *s;
 
@@ -964,7 +964,7 @@ string cMsgMessage::getSenderHost(void) const throw(cMsgException) {
  * @return Receiver time
  * @throws cMsgException
  */
-struct timespec cMsgMessage::getReceiverTime(void) const throw(cMsgException) {
+struct timespec cMsgMessage::getReceiverTime(void) const {
 
   struct timespec t;
 
@@ -985,7 +985,7 @@ struct timespec cMsgMessage::getReceiverTime(void) const throw(cMsgException) {
  * @return Sender time
  * @throws cMsgException
  */
-struct timespec cMsgMessage::getSenderTime(void) const throw(cMsgException) {
+struct timespec cMsgMessage::getSenderTime(void) const {
 
   struct timespec t;
 
@@ -1005,7 +1005,7 @@ struct timespec cMsgMessage::getSenderTime(void) const throw(cMsgException) {
  *
  * @return True if get request
  */
-bool cMsgMessage::isGetRequest(void) const throw(cMsgException) {
+bool cMsgMessage::isGetRequest(void) const {
   
   int b;
 
@@ -1025,7 +1025,7 @@ bool cMsgMessage::isGetRequest(void) const throw(cMsgException) {
  *
  * @return True if get response
  */
-bool cMsgMessage::isGetResponse(void) const throw(cMsgException) {
+bool cMsgMessage::isGetResponse(void) const {
   
   int b;
 
@@ -1046,7 +1046,7 @@ bool cMsgMessage::isGetResponse(void) const throw(cMsgException) {
  * @return True if NULL get response
  * @throws cMsgException
  */
-bool cMsgMessage::isNullGetResponse(void) const throw(cMsgException) {
+bool cMsgMessage::isNullGetResponse(void) const {
   
   int b;
 
@@ -1067,7 +1067,7 @@ bool cMsgMessage::isNullGetResponse(void) const throw(cMsgException) {
  * @param msg Message to make a null response
  * @throws cMsgException
  */
-void cMsgMessage::makeNullResponse(const cMsgMessage &msg) throw(cMsgException) {
+void cMsgMessage::makeNullResponse(const cMsgMessage &msg) {
 
   cMsgMessage_t *t = (cMsgMessage_t*)myMsgPointer;
   cMsgMessage_t *m = (cMsgMessage_t*)msg.myMsgPointer;
@@ -1087,7 +1087,7 @@ void cMsgMessage::makeNullResponse(const cMsgMessage &msg) throw(cMsgException) 
  * @param msg Message to make a null response
  * @throws cMsgException
  */
-void cMsgMessage::makeNullResponse(const cMsgMessage *msg) throw(cMsgException) {
+void cMsgMessage::makeNullResponse(const cMsgMessage *msg) {
 
   cMsgMessage_t *t = (cMsgMessage_t*)myMsgPointer;
   cMsgMessage_t *m = (cMsgMessage_t*)msg->myMsgPointer;
@@ -1107,7 +1107,7 @@ void cMsgMessage::makeNullResponse(const cMsgMessage *msg) throw(cMsgException) 
  * @param msg Message to make a response
  * @throws cMsgException
  */
-void cMsgMessage::makeResponse(const cMsgMessage &msg) throw(cMsgException) {
+void cMsgMessage::makeResponse(const cMsgMessage &msg) {
 
   cMsgMessage_t *t = (cMsgMessage_t*)myMsgPointer;
   cMsgMessage_t *m = (cMsgMessage_t*)msg.myMsgPointer;
@@ -1127,7 +1127,7 @@ void cMsgMessage::makeResponse(const cMsgMessage &msg) throw(cMsgException) {
  * @param msg Message to make a response
  * @throws cMsgException
  */
-void cMsgMessage::makeResponse(const cMsgMessage *msg) throw(cMsgException) {
+void cMsgMessage::makeResponse(const cMsgMessage *msg) {
 
   cMsgMessage_t *t = (cMsgMessage_t*)myMsgPointer;
   cMsgMessage_t *m = (cMsgMessage_t*)msg->myMsgPointer;
@@ -1147,7 +1147,7 @@ void cMsgMessage::makeResponse(const cMsgMessage *msg) throw(cMsgException) {
  * @return Null response message
  * @throws cMsgException
  */
-cMsgMessage *cMsgMessage::nullResponse(void) const throw(cMsgException) {
+cMsgMessage *cMsgMessage::nullResponse(void) const {
 
   void *newMsgPointer;
   if((newMsgPointer=cMsgCreateNullResponseMessage(myMsgPointer))==NULL) {
@@ -1167,7 +1167,7 @@ cMsgMessage *cMsgMessage::nullResponse(void) const throw(cMsgException) {
  * @return Response message
  * @throws cMsgException
  */
-cMsgMessage *cMsgMessage::response(void) const throw(cMsgException) {
+cMsgMessage *cMsgMessage::response(void) const {
 
   void *newMsgPointer;
   if((newMsgPointer=cMsgCreateResponseMessage(myMsgPointer))==NULL) {
@@ -1187,7 +1187,7 @@ cMsgMessage *cMsgMessage::response(void) const throw(cMsgException) {
  * @param b True to make message a get response message
  * @throws cMsgException
  */
-void cMsgMessage::setGetResponse(bool b) throw(cMsgException) {
+void cMsgMessage::setGetResponse(bool b) {
 
   int stat;
   if((stat=cMsgSetGetResponse(myMsgPointer,b))!=CMSG_OK) {
@@ -1205,7 +1205,7 @@ void cMsgMessage::setGetResponse(bool b) throw(cMsgException) {
  * @param b True to make message a null response message
  * @throws cMsgException
  */
-void cMsgMessage::setNullGetResponse(bool b) throw(cMsgException) {
+void cMsgMessage::setNullGetResponse(bool b) {
 
   int stat;
   if((stat=cMsgSetNullGetResponse(myMsgPointer,b))!=CMSG_OK) {
@@ -1223,7 +1223,7 @@ void cMsgMessage::setNullGetResponse(bool b) throw(cMsgException) {
  * @return xml representation of message
  * @throws cMsgException
  */
-string cMsgMessage::toString(void) const throw(cMsgException) {
+string cMsgMessage::toString(void) const {
 
   char *cs;
 
@@ -1250,7 +1250,7 @@ string cMsgMessage::toString(void) const throw(cMsgException) {
  * @return Subscription domain
  * @throws cMsgException
  */
-string cMsgMessage::getSubscriptionDomain(void) const throw(cMsgException) {
+string cMsgMessage::getSubscriptionDomain(void) const {
 
   const char *s;
 
@@ -1276,7 +1276,7 @@ string cMsgMessage::getSubscriptionDomain(void) const throw(cMsgException) {
  * @return Subscription subject
  * @throws cMsgException
  */
-string cMsgMessage::getSubscriptionSubject(void) const throw(cMsgException) {
+string cMsgMessage::getSubscriptionSubject(void) const {
 
   const char *s;
 
@@ -1302,7 +1302,7 @@ string cMsgMessage::getSubscriptionSubject(void) const throw(cMsgException) {
  * @return Subscription type
  * @throws cMsgException
  */
-string cMsgMessage::getSubscriptionType(void) const throw(cMsgException) {
+string cMsgMessage::getSubscriptionType(void) const {
 
   const char *s;
 
@@ -1328,7 +1328,7 @@ string cMsgMessage::getSubscriptionType(void) const throw(cMsgException) {
  * @return Subscription UDL
  * @throws cMsgException
  */
-string cMsgMessage::getSubscriptionUDL(void) const throw(cMsgException) {
+string cMsgMessage::getSubscriptionUDL(void) const {
 
   const char *s;
 
@@ -1354,7 +1354,7 @@ string cMsgMessage::getSubscriptionUDL(void) const throw(cMsgException) {
  * @return Current cue size
  * @throws cMsgException
  */
-int cMsgMessage::getSubscriptionCueSize(void) const throw(cMsgException) {
+int cMsgMessage::getSubscriptionCueSize(void) const {
 
   int i;
 
@@ -1375,7 +1375,7 @@ int cMsgMessage::getSubscriptionCueSize(void) const throw(cMsgException) {
  * @return True if reliable send used
  * @throws cMsgException
  */
-bool cMsgMessage::getReliableSend(void) const throw(cMsgException) {
+bool cMsgMessage::getReliableSend(void) const {
 
   int i;
 
@@ -1396,7 +1396,7 @@ bool cMsgMessage::getReliableSend(void) const throw(cMsgException) {
  * @param b True if reliable send should be used
  * @throws cMsgException
  */
-void cMsgMessage::setReliableSend(bool b) throw(cMsgException) {
+void cMsgMessage::setReliableSend(bool b) {
 
   int i = b ? 1 : 0;
   
@@ -1670,7 +1670,7 @@ cMsg::~cMsg(void) {
  * 
  * @throws cMsgException
  */
-void cMsg::connect(void) throw(cMsgException) {
+void cMsg::connect(void) {
     int stat;
    
     // if we're already initialized (called connect once), we want to reconnect
@@ -1696,7 +1696,7 @@ void cMsg::connect(void) throw(cMsgException) {
  * Disconnects from cMsg system.
  * @throws cMsgException
  */
-void cMsg::disconnect(void) throw(cMsgException) {
+void cMsg::disconnect(void) {
 
   if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 
@@ -1715,7 +1715,7 @@ void cMsg::disconnect(void) throw(cMsgException) {
  * @param msg Message to send
  * @throws cMsgException
  */
-void cMsg::send(cMsgMessage &msg) throw(cMsgException) {
+void cMsg::send(cMsgMessage &msg) {
     
   if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 
@@ -1736,7 +1736,7 @@ void cMsg::send(cMsgMessage &msg) throw(cMsgException) {
  * @param msg Message to send
  * @throws cMsgException
  */
-void cMsg::send(cMsgMessage *msg) throw(cMsgException) {
+void cMsg::send(cMsgMessage *msg) {
   cMsg::send(*msg);
 }
 
@@ -1751,7 +1751,7 @@ void cMsg::send(cMsgMessage *msg) throw(cMsgException) {
  * @param timeout Timeout
  * @throws cMsgException
  */
-int cMsg::syncSend(cMsgMessage &msg, const struct timespec *timeout) throw(cMsgException) {
+int cMsg::syncSend(cMsgMessage &msg, const struct timespec *timeout) {
     
   if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 
@@ -1776,7 +1776,7 @@ int cMsg::syncSend(cMsgMessage &msg, const struct timespec *timeout) throw(cMsgE
  * @param timeout Timeout
  * @throws cMsgException
  */
-int cMsg::syncSend(cMsgMessage *msg, const struct timespec *timeout) throw(cMsgException) {
+int cMsg::syncSend(cMsgMessage *msg, const struct timespec *timeout) {
   return(cMsg::syncSend(*msg, timeout));
 }
 
@@ -1798,7 +1798,7 @@ int cMsg::syncSend(cMsgMessage *msg, const struct timespec *timeout) throw(cMsgE
  *                       some underlying domain's reason
  */
 void *cMsg::subscribe(const string &subject, const string &type, cMsgCallback *cb, void *userArg,
-                      const cMsgSubscriptionConfig *cfg) throw(cMsgException) {
+                      const cMsgSubscriptionConfig *cfg) {
     
   if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 
@@ -1855,7 +1855,7 @@ void *cMsg::subscribe(const string &subject, const string &type, cMsgCallback *c
  *                       some underlying domain's reason
  */
 void *cMsg::subscribe(const string &subject, const string &type, cMsgCallback &cb, void *userArg,
-                      const cMsgSubscriptionConfig *cfg) throw(cMsgException) {
+                      const cMsgSubscriptionConfig *cfg) {
   return(cMsg::subscribe(subject, type, &cb, userArg, cfg));
 }
 
@@ -1869,7 +1869,7 @@ void *cMsg::subscribe(const string &subject, const string &type, cMsgCallback &c
  * @param handle Subscription handle
  * @throws cMsgException
  */
-void cMsg::unsubscribe(void *handle) throw(cMsgException) {
+void cMsg::unsubscribe(void *handle) {
 
     if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 
@@ -1900,7 +1900,7 @@ void cMsg::unsubscribe(void *handle) throw(cMsgException) {
  * @param handle Subscription handle
  * @throws cMsgException
  */
-void cMsg::subscriptionPause(void *handle) throw(cMsgException) {
+void cMsg::subscriptionPause(void *handle) {
 
     if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 
@@ -1923,7 +1923,7 @@ void cMsg::subscriptionPause(void *handle) throw(cMsgException) {
  * @param handle Subscription handle
  * @throws cMsgException
  */
-void cMsg::subscriptionResume(void *handle) throw(cMsgException) {
+void cMsg::subscriptionResume(void *handle) {
 
     if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 
@@ -1946,7 +1946,7 @@ void cMsg::subscriptionResume(void *handle) throw(cMsgException) {
  * @param handle Subscription handle
  * @throws cMsgException
  */
-void cMsg::subscriptionQueueClear(void *handle) throw(cMsgException) {
+void cMsg::subscriptionQueueClear(void *handle) {
 
     if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 
@@ -1970,7 +1970,7 @@ void cMsg::subscriptionQueueClear(void *handle) throw(cMsgException) {
  * @return number of messages currently in the given subscription callback's queue
  * @throws cMsgException
  */
-int cMsg::subscriptionQueueCount(void *handle) throw(cMsgException) {
+int cMsg::subscriptionQueueCount(void *handle) {
 
     if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 
@@ -1995,7 +1995,7 @@ int cMsg::subscriptionQueueCount(void *handle) throw(cMsgException) {
  * @return total number of messages passed to the given subscription's callback
  * @throws cMsgException
  */
-int cMsg::subscriptionMessagesTotal(void *handle) throw(cMsgException) {
+int cMsg::subscriptionMessagesTotal(void *handle) {
 
     if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 
@@ -2020,7 +2020,7 @@ int cMsg::subscriptionMessagesTotal(void *handle) throw(cMsgException) {
  * @return boolean stating whether the given subscription callback's queue is full or not
  * @throws cMsgException
  */
-bool cMsg::subscriptionQueueIsFull(void *handle) throw(cMsgException) {
+bool cMsg::subscriptionQueueIsFull(void *handle) {
 
     if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 
@@ -2047,7 +2047,7 @@ bool cMsg::subscriptionQueueIsFull(void *handle) throw(cMsgException) {
  * @return Reply message
  * @throws cMsgException
  */
-cMsgMessage *cMsg::sendAndGet(cMsgMessage &sendMsg, const struct timespec *timeout) throw(cMsgException) {
+cMsgMessage *cMsg::sendAndGet(cMsgMessage &sendMsg, const struct timespec *timeout) {
     
   if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 
@@ -2075,7 +2075,7 @@ cMsgMessage *cMsg::sendAndGet(cMsgMessage &sendMsg, const struct timespec *timeo
  * @return Reply message
  * @throws cMsgException
  */
-cMsgMessage *cMsg::sendAndGet(cMsgMessage *sendMsg, const struct timespec *timeout) throw(cMsgException) {
+cMsgMessage *cMsg::sendAndGet(cMsgMessage *sendMsg, const struct timespec *timeout) {
 
   if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 
@@ -2103,7 +2103,7 @@ cMsgMessage *cMsg::sendAndGet(cMsgMessage *sendMsg, const struct timespec *timeo
  * @return Matching message
  * @throws cMsgException
  */
-cMsgMessage *cMsg::subscribeAndGet(const string &subject, const string &type, const struct timespec *timeout) throw(cMsgException) {
+cMsgMessage *cMsg::subscribeAndGet(const string &subject, const string &type, const struct timespec *timeout) {
 
   if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 
@@ -2128,7 +2128,7 @@ cMsgMessage *cMsg::subscribeAndGet(const string &subject, const string &type, co
  * @param timeout Timeout
  * @throws cMsgException
  */
-void cMsg::flush(const struct timespec *timeout) throw(cMsgException) {
+void cMsg::flush(const struct timespec *timeout) {
     
   if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 
@@ -2147,7 +2147,7 @@ void cMsg::flush(const struct timespec *timeout) throw(cMsgException) {
  * Enables delivery of messages to callbacks.
  * @throws cMsgException
  */
-void cMsg::start(void) throw(cMsgException) {
+void cMsg::start(void) {
 
   if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 
@@ -2166,7 +2166,7 @@ void cMsg::start(void) throw(cMsgException) {
  * Disables delivery of messages to callbacks.
  * @throws cMsgException
  */
-void cMsg::stop(void) throw(cMsgException) {
+void cMsg::stop(void) {
 
   if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 
@@ -2227,7 +2227,7 @@ string cMsg::getUDL(void) const {
  * @param udl new UDL
  * @throws cMsgException
  */
-void cMsg::setUDL(const string &udl) throw(cMsgException) {
+void cMsg::setUDL(const string &udl) {
 
     int stat;
     if((stat=cMsgSetUDL(myDomainId,udl.c_str()))!=CMSG_OK) {
@@ -2245,7 +2245,7 @@ void cMsg::setUDL(const string &udl) throw(cMsgException) {
  * @return UDL of current connection
  * @throws cMsgException
  */
-string cMsg::getCurrentUDL(void) const throw(cMsgException) {
+string cMsg::getCurrentUDL(void) const {
     const char *s;
 
     int stat;
@@ -2270,7 +2270,7 @@ string cMsg::getCurrentUDL(void) const throw(cMsgException) {
  * @return True if connected
  * @throws cMsgException
  */
-bool cMsg::isConnected(void) const throw(cMsgException) {
+bool cMsg::isConnected(void) const {
 
   if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 
@@ -2292,7 +2292,7 @@ bool cMsg::isConnected(void) const throw(cMsgException) {
  * @return True if receiving messages
  * @throws cMsgException
  */
-bool cMsg::isReceiving(void) const throw(cMsgException) {
+bool cMsg::isReceiving(void) const {
 
   if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 
@@ -2315,7 +2315,7 @@ bool cMsg::isReceiving(void) const throw(cMsgException) {
  * @param userArg Arg passed to handler upon shutdown
  * @throws cMsgException
  */
-void cMsg::setShutdownHandler(cMsgShutdownHandler *handler, void* userArg) throw(cMsgException) {
+void cMsg::setShutdownHandler(cMsgShutdownHandler *handler, void* userArg) {
 
   if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 
@@ -2337,7 +2337,7 @@ void cMsg::setShutdownHandler(cMsgShutdownHandler *handler, void* userArg) throw
  * @param flag Shutdown flag
  * @throws cMsgException
  */
-void cMsg::shutdownClients(const string &client, int flag) throw(cMsgException) {
+void cMsg::shutdownClients(const string &client, int flag) {
 
   if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 
@@ -2359,7 +2359,7 @@ void cMsg::shutdownClients(const string &client, int flag) throw(cMsgException) 
  * @param flag Shutdown flag
  * @throws cMsgException
  */
-void cMsg::shutdownServers(const string &server, int flag) throw(cMsgException) {
+void cMsg::shutdownServers(const string &server, int flag) {
 
   if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 
@@ -2381,7 +2381,7 @@ void cMsg::shutdownServers(const string &server, int flag) throw(cMsgException) 
  * @return Message containing monitoring information in text field
  * @throws cMsgException
  */
-cMsgMessage *cMsg::monitor(const string &monString) throw(cMsgException) {
+cMsgMessage *cMsg::monitor(const string &monString) {
 
   if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 
@@ -2407,7 +2407,7 @@ cMsgMessage *cMsg::monitor(const string &monString) throw(cMsgException) {
  * @param monString Monitoring string
  * @throws cMsgException
  */
- void cMsg::setMonitoringString(const string &monString) throw(cMsgException) {
+ void cMsg::setMonitoringString(const string &monString) {
 
   if(!initialized)throw(cMsgException(cMsgPerror(CMSG_NOT_INITIALIZED),CMSG_NOT_INITIALIZED));
 


### PR DESCRIPTION
Explicit throw statements in method declarations were deprecated in c++11 and are now treated as errors in c++17 and later. This removes them to make modern compilers happy, but does not change the functionality of the code.